### PR TITLE
Add CLI for Gemini API

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,14 @@
 # Pause-ai
+
+This repository holds minimal examples for trying the Gemini REST API.
+
+The `quickstarts/rest/Prompting_REST.ipynb` notebook demonstrates using `curl`.
+
+A small command line interface is available in `gemini_interface.py`.
+Set your API key in the `GOOGLE_API_KEY` environment variable and run:
+
+```bash
+python gemini_interface.py "Give me python code to sort a list."
+```
+
+

--- a/gemini_interface.py
+++ b/gemini_interface.py
@@ -1,0 +1,39 @@
+#!/usr/bin/env python3
+"""Simple CLI for the Gemini REST API."""
+import os
+import sys
+import requests
+
+API_URL = "https://generativelanguage.googleapis.com/v1beta/models/gemini-2.0-flash:generateContent"
+
+
+def main(prompt: str) -> None:
+    api_key = os.getenv("GOOGLE_API_KEY")
+    if not api_key:
+        raise SystemExit("GOOGLE_API_KEY environment variable not set")
+
+    url = f"{API_URL}?key={api_key}"
+    body = {
+        "contents": [{
+            "parts": [{"text": prompt}]
+        }]
+    }
+
+    response = requests.post(url, json=body)
+    response.raise_for_status()
+    data = response.json()
+    try:
+        text = data["candidates"][0]["content"]["parts"][0]["text"]
+    except Exception:
+        print(data)
+    else:
+        print(text)
+
+
+if __name__ == "__main__":
+    if len(sys.argv) < 2:
+        print("Usage: python gemini_interface.py 'your prompt'")
+        raise SystemExit(1)
+    prompt = " ".join(sys.argv[1:])
+    main(prompt)
+


### PR DESCRIPTION
## Summary
- provide gemini_interface.py as a simple command line interface to call the Gemini REST API
- document how to run the script in the README

## Testing
- `git status --short`


------
https://chatgpt.com/codex/tasks/task_e_6878c841c40c8332ba3865fbdc3ad00d