### PR TITLE
Add minimal Flask dashboard for managing OpenAI projects

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,4 +11,32 @@ Set your API key in the `GOOGLE_API_KEY` environment variable and run:
 python gemini_interface.py "Give me python code to sort a list."
 ```
 
+## Project Dashboard
+
+The repository also includes a minimal Flask dashboard for tracking projects that
+interact with the OpenAI API.
+
+### Setup
+
+1. Install dependencies:
+
+   ```bash
+   pip install -r requirements.txt
+   ```
+
+2. Set your OpenAI API key:
+
+   ```bash
+   export OPENAI_API_KEY="YOUR_KEY_HERE"
+   ```
+
+3. Run the dashboard:
+
+   ```bash
+   python dashboard/app.py
+   ```
+
+Then open [http://localhost:5000](http://localhost:5000) to manage projects and
+trigger updates via the OpenAI API.
+
 

--- a/dashboard/app.py
+++ b/dashboard/app.py
@@ -1,0 +1,68 @@
+import os
+import sqlite3
+from flask import Flask, request, render_template, redirect, url_for
+from openai import OpenAI
+
+app = Flask(__name__)
+DATABASE = os.path.join(os.path.dirname(__file__), 'dashboard.db')
+client = OpenAI(api_key=os.getenv("OPENAI_API_KEY"))
+
+
+def get_db():
+    conn = sqlite3.connect(DATABASE)
+    conn.row_factory = sqlite3.Row
+    return conn
+
+
+def init_db():
+    conn = get_db()
+    conn.execute(
+        """CREATE TABLE IF NOT EXISTS projects (
+        id INTEGER PRIMARY KEY AUTOINCREMENT,
+        name TEXT NOT NULL,
+        prompt TEXT NOT NULL,
+        last_response TEXT
+    )"""
+    )
+    conn.commit()
+    conn.close()
+
+
+@app.route('/', methods=['GET', 'POST'])
+def index():
+    conn = get_db()
+    if request.method == 'POST':
+        name = request.form['name']
+        prompt = request.form['prompt']
+        conn.execute(
+            'INSERT INTO projects (name, prompt, last_response) VALUES (?, ?, ?)',
+            (name, prompt, '')
+        )
+        conn.commit()
+        return redirect(url_for('index'))
+    projects = conn.execute('SELECT * FROM projects').fetchall()
+    conn.close()
+    return render_template('index.html', projects=projects)
+
+
+@app.route('/update/<int:project_id>', methods=['POST'])
+def update(project_id):
+    conn = get_db()
+    project = conn.execute('SELECT * FROM projects WHERE id=?', (project_id,)).fetchone()
+    if project:
+        response = client.responses.create(
+            model="gpt-4o-mini",
+            input=project['prompt']
+        )
+        conn.execute(
+            'UPDATE projects SET last_response=? WHERE id=?',
+            (response.output_text, project_id)
+        )
+        conn.commit()
+    conn.close()
+    return redirect(url_for('index'))
+
+
+if __name__ == '__main__':
+    init_db()
+    app.run(debug=True)

--- a/dashboard/templates/index.html
+++ b/dashboard/templates/index.html
@@ -1,0 +1,26 @@
+<!doctype html>
+<html lang="en">
+<head>
+  <meta charset="utf-8">
+  <title>Project Dashboard</title>
+</head>
+<body>
+  <h1>Projects</h1>
+  <form method="post">
+    <input type="text" name="name" placeholder="Project name" required>
+    <input type="text" name="prompt" placeholder="Prompt" required>
+    <button type="submit">Add project</button>
+  </form>
+  <ul>
+    {% for project in projects %}
+    <li>
+      <strong>{{ project['name'] }}</strong>
+      <form action="{{ url_for('update', project_id=project['id']) }}" method="post" style="display:inline;">
+        <button type="submit">Update</button>
+      </form>
+      <p>{{ project['last_response'] }}</p>
+    </li>
+    {% endfor %}
+  </ul>
+</body>
+</html>

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,2 @@
+flask
+openai


### PR DESCRIPTION
## Summary
- add simple Flask app with SQLite to track projects and fetch updates from OpenAI
- include HTML template and requirements file
- document dashboard setup in README

## Testing
- `python -m py_compile dashboard/app.py`
- `pip install -r requirements.txt`


------
https://chatgpt.com/codex/tasks/task_e_688ff77e8c308332b06ade68b79e2946